### PR TITLE
Fixed missspelling in DisplayName.

### DIFF
--- a/umatiGateway/OPC/JSONConverter.cs
+++ b/umatiGateway/OPC/JSONConverter.cs
@@ -185,7 +185,7 @@ namespace UmatiGateway.OPC
             JObject jObject = new JObject();
             jObject.Add("NamespaceUri", this.Convert(euInformation.NamespaceUri));
             jObject.Add("UnitId", this.Convert(euInformation.UnitId));
-            jObject.Add("DisplayNmae", this.Convert(euInformation.DisplayName));
+            jObject.Add("DisplayName", this.Convert(euInformation.DisplayName));
             jObject.Add("Description", this.Convert(euInformation.Description));
             return jObject;
         }


### PR DESCRIPTION
In EUInformation DisplayName was spelled as DisplayNmae. This is fixed now.