### PR TITLE
Added custom fix for broken server.

### DIFF
--- a/umatiGateway/Configuration/Files/LocalConfigLocalSampleServer.xml
+++ b/umatiGateway/Configuration/Files/LocalConfigLocalSampleServer.xml
@@ -5,7 +5,7 @@
   <OPCConnection serverendpoint="opc.tcp://127.0.0.1:4840" authentication="None" user="" password="" />
   <MqttConnection serverendpoint="mqtt://localhost:1883" user="" password="" clientId="company/client" prefix="umati/v2" />
   <PublishedNodes>
-    <PublishedNode type="Numeric" namespaceurl="http://example.com/BasicMachineTool/" nodeId="66382" />
+	  <PublishedNode type="Numeric" namespaceurl="http://vdma.org/UA/LaserSystem-Example/" nodeId="5003"/>
   </PublishedNodes>
   <CustomEncodings>
     <CustomEncoding name="GMSResultDataTypeEncoding" active="False" />

--- a/umatiGateway/OPC/MqttProvider.cs
+++ b/umatiGateway/OPC/MqttProvider.cs
@@ -876,39 +876,30 @@ namespace UmatiGateway.OPC
                                 this.placeholderVariablesWithTypeDefinition.Add(child, this.getInstanceNsu(typeDefinition, false));
                             }
                             JToken dataValue = getDataValueAsObject(child);
-                            bool isProperty = false;
                             bool shorten = false;
                             bool useValueIndentation = true;
-
-                            if (typeDefinition == VariableTypeIds.PropertyType)
+                            if (shortenVariables)
                             {
-                                isProperty = true;
-                            }
-                            else
-                            {
-                                if (shortenVariables)
+                                List<NodeId> nodeIds = new List<NodeId>();
+                                if (this.client.configuration.includeStructuredComponents)
                                 {
-                                    List<NodeId> nodeIds = new List<NodeId>();
-                                    if (this.client.configuration.includeStructuredComponents)
-                                    {
-                                        nodeIds = this.client.BrowseLocalNodeIds(child, BrowseDirection.Forward, (int)NodeClass.Variable, ReferenceTypeIds.HierarchicalReferences, true);
-                                    }
-                                    else
-                                    {
-                                        nodeIds = this.client.BrowseLocalNodeIdsExcludeReference(child, BrowseDirection.Forward, (int)NodeClass.Variable, ReferenceTypeIds.HierarchicalReferences, true, ReferenceTypeIds.HasStructuredComponent);
-                                    }
-                                    if (nodeIds.Count == 0)
-                                    {
-                                        shorten = true;
-                                    }
-                                    if (this.getInstanceNsu(typeDefinition, false) == "nsu=http://opcfoundation.org/UA/GMS/;i=2004")
-                                    {
-                                        Logger.Trace("Not use ValueIndentation");
-                                        useValueIndentation = false;
-                                    }
+                                    nodeIds = this.client.BrowseLocalNodeIds(child, BrowseDirection.Forward, (int)NodeClass.Variable, ReferenceTypeIds.HierarchicalReferences, true);
+                                }
+                                else
+                                {
+                                    nodeIds = this.client.BrowseLocalNodeIdsExcludeReference(child, BrowseDirection.Forward, (int)NodeClass.Variable, ReferenceTypeIds.HierarchicalReferences, true, ReferenceTypeIds.HasStructuredComponent);
+                                }
+                                if (nodeIds.Count == 0)
+                                {
+                                    shorten = true;
+                                }
+                                if (this.getInstanceNsu(typeDefinition, false) == "nsu=http://opcfoundation.org/UA/GMS/;i=2004")
+                                {
+                                    Logger.Trace("Not use ValueIndentation");
+                                    useValueIndentation = false;
                                 }
                             }
-                            if (isProperty || shorten || !useValueIndentation)
+                            if (shorten || !useValueIndentation)
                             {
                                 if (dataValue is JValue)
                                 {


### PR DESCRIPTION

The special-case handling for PropertyType variables in the JSON creation logic has been removed. All variables are now handled consistently, based only on the "shorten" and "useValueIndentation" flags. This likely makes the output JSON structure for PropertyType variables less special or different, and may help simplify or standardize how all variables are serialized.