### PR TITLE
Included Opc Ua Stack Logs in default Application Logging

### DIFF
--- a/umatiGateway/Core/OPC/umatiGatewayApp.cs
+++ b/umatiGateway/Core/OPC/umatiGatewayApp.cs
@@ -6,8 +6,8 @@ using System.Reflection;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using NLog.Extensions.Logging;
 using Opc.Ua;
-using Opc.Ua.Client;
 using umatiGateway.Core.Configuration;
 using umatiGateway.Core.Mqtt;
 using umatiGateway.Core.PubSub;
@@ -54,18 +54,44 @@ namespace umatiGateway.Core.OPC
 
             string logLevelstring = ActiveConfiguration.LogLevel ?? "";
             NLog.LogLevel logLevel = NLog.LogLevel.Info;
+            Microsoft.Extensions.Logging.LogLevel opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Information;
             switch (logLevelstring)
             {
-                case "Trace": logLevel = NLog.LogLevel.Trace; break;
-                case "Debug": logLevel = NLog.LogLevel.Debug; break;
-                case "Info": logLevel = NLog.LogLevel.Info; break;
-                case "Warn": logLevel = NLog.LogLevel.Warn; break;
-                case "Error": logLevel = NLog.LogLevel.Error; break;
+                case "Trace":
+                    logLevel = NLog.LogLevel.Trace;
+                    opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Trace;
+                    break;
+                case "Debug":
+                    logLevel = NLog.LogLevel.Debug;
+                    opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Debug;
+                    break;
+                case "Info":
+                    logLevel = NLog.LogLevel.Info;
+                    opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Information;
+                    break;
+                case "Warn":
+                    logLevel = NLog.LogLevel.Warn;
+                    opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Warning;
+                    break;
+                case "Error":
+                    logLevel = NLog.LogLevel.Error;
+                    opcUaLogLevel = Microsoft.Extensions.Logging.LogLevel.Error;
+                    break;
                 default: logLevel = NLog.LogLevel.Info; break;
             }
             config.AddRule(logLevel, NLog.LogLevel.Fatal, logconsole);
             config.AddRule(logLevel, NLog.LogLevel.Fatal, logfile);
             LogManager.Configuration = config;
+            // Set logger for OPC UA stack
+            ILoggerFactory loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder
+                    .ClearProviders()
+                    .AddNLog() // Connect NLog to ILoggerFactory
+                    .SetMinimumLevel(opcUaLogLevel);
+            });
+            Utils.SetLogger(loggerFactory.CreateLogger("OpcUa"));
+            Utils.SetLogLevel(opcUaLogLevel);
         }
 
         public void StartUp()

--- a/umatiGateway/Host/Program.cs
+++ b/umatiGateway/Host/Program.cs
@@ -8,8 +8,20 @@ using umatiGateway.Hub;
 using UmatiGateway;
 
 Logger Logger = LogManager.GetCurrentClassLogger();
+AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
+{
+    var ex = e.ExceptionObject as Exception;
+    Logger.Error(ex, $"[Unhandled Exception] {ex?.Message}");
+};
+
+TaskScheduler.UnobservedTaskException += (sender, e) =>
+{
+    Logger.Error(e.Exception, $"[Unobserved Task Exception] {e.Exception?.Message}");
+    e.SetObserved();
+};
+
 ClientFactory clientFactory = new ClientFactory();
-UmatiGatewayApp umatiGateway = clientFactory.getClient("Egal");
+UmatiGatewayApp umatiGateway = clientFactory.getClient("UmatiAppClient");
 if (umatiGateway.ActiveConfiguration.StartConfiguration.StartWebUI == true)
 {
     var builder = WebApplication.CreateBuilder(args);
@@ -24,7 +36,7 @@ if (umatiGateway.ActiveConfiguration.StartConfiguration.StartWebUI == true)
         }
         else
         {
-            Logger.Error($"Invalid formatted Uri specified: {uriResult}");
+            Logger.Error($"Invalid formatted Uri specified: {url}");
         }
     }
     // Add services to the container

--- a/umatiGateway/umatiGateway.csproj
+++ b/umatiGateway/umatiGateway.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="6.0.2" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.2" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua" Version="1.5.376.235" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes.Debug" Version="1.5.376.235" />
   </ItemGroup>


### PR DESCRIPTION
Opc Ua Loglevel is defined the same as Application LogLevel.
Added Nuget package for NLog.Extended.Logging.
Added catching and logging of unhandled Exceptions on program root.