### PR TITLE
Fix minor errors to enhance server compatability

### DIFF
--- a/umatiGateway/Core/OPC/OpcUaClient.cs
+++ b/umatiGateway/Core/OPC/OpcUaClient.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography.X509Certificates;
 using NLog;
 using Opc.Ua;
 using Opc.Ua.Client;
-using LogLevel = NLog.LogLevel;
 
 namespace umatiGateway.Core.OPC
 {
@@ -124,7 +123,7 @@ namespace umatiGateway.Core.OPC
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.Warn, ex, "Failed to read Node with NodeId: {nodeId}", nodeId);
+                Logger.Warn(ex, "Failed to read Node with NodeId: {nodeId}", nodeId);
                 return null;
             }
         }

--- a/umatiGateway/Core/OPC/OpcUaClient.cs
+++ b/umatiGateway/Core/OPC/OpcUaClient.cs
@@ -121,10 +121,14 @@ namespace umatiGateway.Core.OPC
             {
                 return session.ReadNode(nodeId);
             }
-            catch (Exception ex)
+            catch (ServiceResultException ex) when (ex.StatusCode == Opc.Ua.StatusCodes.BadNodeIdUnknown)
             {
                 Logger.Warn(ex, "Failed to read Node with NodeId: {nodeId}", nodeId);
                 return null;
+            }
+            catch (Exception ex)
+            {
+                throw new OpcUaException($"Failed to read Node with NodeId: {nodeId}", ex);
             }
         }
         public void ConnectEvents(OpcUaEventListener opcUaEventListener)

--- a/umatiGateway/Core/OPC/OpcUaClient.cs
+++ b/umatiGateway/Core/OPC/OpcUaClient.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using NLog;
 using Opc.Ua;
 using Opc.Ua.Client;
+using LogLevel = NLog.LogLevel;
 
 namespace umatiGateway.Core.OPC
 {
@@ -123,7 +124,8 @@ namespace umatiGateway.Core.OPC
             }
             catch (Exception ex)
             {
-                throw new OpcUaException($"Failed to read Node with NodeId: {nodeId}", ex);
+                Logger.Log(LogLevel.Warn, ex, "Failed to read Node with NodeId: {nodeId}", nodeId);
+                return null;
             }
         }
         public void ConnectEvents(OpcUaEventListener opcUaEventListener)

--- a/umatiGateway/Pages/OPCSubscriptions2.cshtml.cs
+++ b/umatiGateway/Pages/OPCSubscriptions2.cshtml.cs
@@ -81,7 +81,14 @@ namespace UmatiGateway.Pages
                             Node? node = this.app.OpcUaClient.ReadNode(childNodeId);
                             if (node != null)
                             {
-                                childNode.Description = node.Description.ToString();
+                                if (node.Description != null)
+                                {
+                                    childNode.Description = node.Description.ToString();
+                                }
+                                else
+                                {
+                                    childNode.Description = "";
+                                }
                             }
                             try
                             {


### PR DESCRIPTION
Fixed 2 bugs, described in issue #272 

- Gateway's "Opc Subscriptions" Tab can now work with Nodes that are missing their Description
- Changed the return behavior of the OpcUaClient to return null instead of throwing.
  - Most references to the function compare against null and to not try catch. Therefore throwing will cause issues in most consumers.