### PR TITLE
Unzip DEBs from artifacts for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-24.04
-    needs: [build-linux, build-windows, docker]
+    needs: [build-linux, build-windows]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -191,20 +191,30 @@ jobs:
           workflow: build.yml
           workflow_conclusion: success
           repo: ${{ github.repository }}
-          commit: ${{github.event.pull_request.head.sha}}
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
           if_no_artifact_found: fail
           skip_unpack: true
-      - name: Checksum
+      - name: Display structure of downloaded files
         run: |
           #!/bin/bash
-          sha256sum ./*.zip > SHA256-checksums
-      - name: Display structure of downloaded files
-        run: ls -R
+          ls -R .
+      - name: Unzip DEBs
+        run: |
+          for zip in umatiGateway-ubuntu-*.zip; do
+            [ -f "$zip" ] || continue
+            unzip -p "$zip" > "${zip%.zip}.deb" && rm "$zip"
+          done
+      - name: Generate checksums
+        run: |
+          #!/bin/bash
+          sha256sum ./*.deb ./*.zip > SHA256-checksums
+          cat SHA256-checksums
       - name: Release
         uses: softprops/action-gh-release@v3.0.2
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
+            ./*.deb
             ./*.zip
-            SHA256-checksums
+            ./SHA256-checksums


### PR DESCRIPTION
* Don't require 'docker' job to do 'release';
* when downloading artifacts, use `github.sha` if `github.event.pull_request.head.sha` is empty;
* unpack debs from and delete `umatiGateway-ubuntu-*.zip`;
* include `deb` files in checksum calculation;
* make release with resulting Linux `deb` and Windows `zip` files.

Example: https://github.com/ainglessi/umatiGateway/releases/tag/v0.0.2